### PR TITLE
BugPatch: Patch a minor bug from previous release

### DIFF
--- a/strm-generator.py
+++ b/strm-generator.py
@@ -287,7 +287,7 @@ def walk(origin_id: str, service: Resource, orig_path: str, item_details: Dict[s
                 file_content = f'plugin://plugin.googledrive/?action=play&item_id={item["id"]}'
                 if 'teamDriveId' in item:
                     # Adding this part only for items present in a teamdrive.
-                    file_content += f'&item_driveid={item["teamDriveId"]}&teamDriveId={item["teamDriveId"]}'
+                    file_content += f'&item_driveid={item["teamDriveId"]}&driveId={item["teamDriveId"]}'
 
                 file_content += f'&content_type=video'
                 with open(join(cur_path, item['name']+'.strm'), 'w+') as f:


### PR DESCRIPTION
This commit includes an otherwise minor bug patch that 
caused the script to break mid-way.

Fix the content of the strm file being written to, ensuring that 
the file can be parsed correctly by the add-on as needed. 
Due to some changes in the add-on itself, and a minor 
typo on my end, the strm files being generated could not be 
parsed correctly by the add-on, as a result. This change is 
intended to fix this error.